### PR TITLE
Telemetry

### DIFF
--- a/lagom-client-restaurant/build.sbt
+++ b/lagom-client-restaurant/build.sbt
@@ -12,12 +12,21 @@ lazy val `menu-item-api` = (project in file("menu-item-api"))
     libraryDependencies += lagomScaladslApi
   )
 
+lazy val cinnamonSettings = Seq(
+  cinnamon in run := true,
+  cinnamon in test := true
+)
+
 lazy val `menu-item-impl` = (project in file("menu-item-impl"))
   .enablePlugins(LagomScala)
+  .enablePlugins(Cinnamon)
   .settings(
     libraryDependencies ++= lagomImplDeps
+    ++ cinnamonPrometheusDeps
+    ++ cinnamonLagomDeps
   )
   .settings(lagomForkedTestSettings)
+  .settings(cinnamonSettings)
   .dependsOn(`menu-item-api`)
 
 //lazy val `order-api` = (project in file("order-api"))
@@ -54,6 +63,7 @@ lazy val `menu-item-impl` = (project in file("menu-item-impl"))
 lazy val `restaurant-client` = (project in file("restaurant-client"))
   .enablePlugins(JavaAppPackaging)
   .enablePlugins(DockerPlugin)
+  .enablePlugins(Cinnamon)
   .settings(
     libraryDependencies ++= Seq(
       lagomScaladslClient,
@@ -68,4 +78,5 @@ lazy val `restaurant-client` = (project in file("restaurant-client"))
     )
   )
   .settings(dockerBaseImage := "openjdk:8-jre-slim")
+  .settings(cinnamonSettings)
   .dependsOn(/*`order-api`,*/`menu-item-api`)

--- a/lagom-client-restaurant/build.sbt
+++ b/lagom-client-restaurant/build.sbt
@@ -76,6 +76,8 @@ lazy val `restaurant-client` = (project in file("restaurant-client"))
       sprayJson,
       scalaTest
     )
+      ++ cinnamonPrometheusDeps
+      ++ cinnamonAkkaHttpDeps
   )
   .settings(dockerBaseImage := "openjdk:8-jre-slim")
   .settings(cinnamonSettings)

--- a/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
+++ b/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
@@ -65,3 +65,14 @@ akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point
 
 #Shutdown if we have not joined a cluster after one minute.
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 300s
+
+# Telemetry
+cinnamon.lagom.http.servers {
+  "*:*" {
+    paths {
+      "*" {
+        metrics = on
+      }
+    }
+  }
+}

--- a/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
+++ b/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
@@ -66,7 +66,10 @@ akka.management.cluster.bootstrap.contact-point-discovery.required-contact-point
 #Shutdown if we have not joined a cluster after one minute.
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 300s
 
-# Telemetry
+# Lagom Cinnamon circuit breaker metrics - https://developer.lightbend.com/docs/telemetry/current/instrumentations/lagom/lagom-configuration.html#circuit-breaker-configuration
+lagom.spi.circuit-breaker-metrics-class = "cinnamon.lagom.CircuitBreakerInstrumentation"
+
+# Lagom Telemetry for servers - https://developer.lightbend.com/docs/telemetry/current/instrumentations/lagom/lagom-configuration.html#example-configuration-2
 cinnamon.lagom.http.servers {
   "*:*" {
     paths {
@@ -74,5 +77,26 @@ cinnamon.lagom.http.servers {
         metrics = on
       }
     }
+  }
+}
+
+# Persistent entity config - https://developer.lightbend.com/docs/telemetry/current/instrumentations/lagom/lagom-configuration.html#lagom-persistent-entities
+cinnamon.akka {
+  actors {
+    "MenuItemEntity-Actors" {
+      report-by = group
+      includes = ["/system/sharding/MenuItemEntity/*"]
+      excludes = ["akka.cluster.sharding.Shard"]
+    }
+  }
+}
+
+# exporting metrics for lightbend console
+cinnamon.prometheus {
+  exporters += http-server
+
+  http-server {
+    host = "0.0.0.0"
+    port = 9001
   }
 }

--- a/lagom-client-restaurant/project/Dependencies.scala
+++ b/lagom-client-restaurant/project/Dependencies.scala
@@ -1,3 +1,4 @@
+import com.lightbend.cinnamon.sbt.Cinnamon
 import com.lightbend.lagom.core.LagomVersion
 import com.lightbend.lagom.sbt.LagomImport.{lagomScaladslKafkaBroker, lagomScaladslPersistenceCassandra, lagomScaladslTestKit}
 import sbt._
@@ -41,5 +42,15 @@ object Dependencies {
     akkaClusterBootstrap,
     macwire,
     scalaTest
+  )
+
+  val cinnamonPrometheusDeps = Seq(
+    Cinnamon.library.cinnamonPrometheus,
+    Cinnamon.library.cinnamonPrometheusHttpServer
+  )
+
+  val cinnamonLagomDeps = Seq(
+    Cinnamon.library.cinnamonLagom,
+    Cinnamon.library.cinnamonJvmMetricsProducer
   )
 }

--- a/lagom-client-restaurant/project/Dependencies.scala
+++ b/lagom-client-restaurant/project/Dependencies.scala
@@ -51,6 +51,15 @@ object Dependencies {
 
   val cinnamonLagomDeps = Seq(
     Cinnamon.library.cinnamonLagom,
-    Cinnamon.library.cinnamonJvmMetricsProducer
+    Cinnamon.library.cinnamonJvmMetricsProducer,
+    Cinnamon.library.cinnamonScala
+  )
+
+  val cinnamonAkkaHttpDeps = Seq(
+    Cinnamon.library.cinnamonAkka,
+    Cinnamon.library.cinnamonAkkaHttp,
+    Cinnamon.library.cinnamonJvmMetricsProducer,
+    Cinnamon.library.cinnamonScala,
+    Cinnamon.library.cinnamonLagom
   )
 }

--- a/lagom-client-restaurant/project/plugins.sbt
+++ b/lagom-client-restaurant/project/plugins.sbt
@@ -1,2 +1,5 @@
 // The Lagom plugin
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.1")
+addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.11.4")
+credentials += Credentials(Path.userHome / ".lightbend" / "commercial.credentials")
+resolvers += Resolver.url("lightbend-commercial", url("https://repo.lightbend.com/commercial-releases"))(Resolver.ivyStylePatterns)

--- a/lagom-client-restaurant/restaurant-client/deploy/kubernetes/restaurant-client-deployment.yaml
+++ b/lagom-client-restaurant/restaurant-client/deploy/kubernetes/restaurant-client-deployment.yaml
@@ -28,7 +28,6 @@ spec:
             - name: prometheus # Used for Enterprise Suite Metrics
               containerPort: 9001
               protocol: TCP
-          endpoint:
           envFrom:
             - configMapRef:
                 name: restaurant-client-config

--- a/lagom-client-restaurant/restaurant-client/deploy/kubernetes/restaurant-client-ingress.yaml
+++ b/lagom-client-restaurant/restaurant-client/deploy/kubernetes/restaurant-client-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: restaurant-client-ingress
 spec:
   rules:
-    - host: local-minikube.com
+    - host: minikube.local
       http:
         paths:
           - path: /

--- a/lagom-client-restaurant/restaurant-client/src/main/resources/application.conf
+++ b/lagom-client-restaurant/restaurant-client/src/main/resources/application.conf
@@ -24,3 +24,25 @@ cinnamon.akka.http.servers {
         }
     }
 }
+
+#lagom client - https://developer.lightbend.com/docs/telemetry/current/instrumentations/lagom/lagom-configuration.html#client-metrics-configuration
+cinnamon.lagom.http.clients {
+    "*:*" {
+        service-name = "menu-item-svc"
+        paths {
+            "*" {
+                metrics = on
+            }
+        }
+    }
+}
+
+# exporting metrics for lightbend console
+cinnamon.prometheus {
+    exporters += http-server
+
+    http-server {
+        host = "0.0.0.0"
+        port = 9001
+    }
+}

--- a/lagom-client-restaurant/restaurant-client/src/main/resources/application.conf
+++ b/lagom-client-restaurant/restaurant-client/src/main/resources/application.conf
@@ -13,3 +13,14 @@ akka {
     loggers = ["akka.event.slf4j.Slf4jLogger"]
     logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
+
+# telemetry
+cinnamon.akka.http.servers {
+    "*:*" {
+        paths {
+            "*" {
+                metrics = on
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enabled telemetry for the Lagom and AkkaHTTP applications.  This telemetry works with Lightbend Console, in a default configuration.