### PR TITLE
Simplify configuration

### DIFF
--- a/lagom-client-restaurant/menu-item-impl/deploy/kubernetes/menu-item-config.yaml
+++ b/lagom-client-restaurant/menu-item-impl/deploy/kubernetes/menu-item-config.yaml
@@ -3,7 +3,5 @@ kind: ConfigMap
 metadata:
   name: menu-item-config
 data:
-  CASSANDRA_CONTACT_POINT: "cassandra.cassandra"
-  KAFKA_BROKERS_SERVICE_URL: "restaurant-strimzi-kafka-bootstrap.kafka:9092"
-  #ALLOWED_HOST: "menu-item-svc.default"
-  ALLOWED_HOST: "."
+  CASSANDRA_SERVICE_NAME: "_cql._tcp.cassandra.cassandra"
+  KAFKA_SERVICE_NAME: "_clients._tcp.restaurant-strimzi-kafka-bootstrap.kafka"

--- a/lagom-client-restaurant/menu-item-impl/deploy/kubernetes/menu-item-deployment.yaml
+++ b/lagom-client-restaurant/menu-item-impl/deploy/kubernetes/menu-item-deployment.yaml
@@ -27,8 +27,6 @@
          ports:
          - name: http
            containerPort: 9000
-         - name: akka-remote
-           containerPort: 2551
          - name: akka-mgmt-http
            containerPort: 8558
          - name: prometheus # Used for Enterprise Suite Metrics
@@ -37,14 +35,8 @@
          - configMapRef:
              name: menu-item-config
          env:
-           - name: "HTTP_BIND_ADDRESS"
-             value: "0.0.0.0"
            - name: "JAVA_OPTS"
              value: "-Dconfig.resource=application.prod.conf -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dpidfile.path=/dev/null"
-           - name: "HOST_ADDRESS"
-             valueFrom:
-               fieldRef:
-                 fieldPath: "status.podIP"
          resources:
            requests:
              memory: "256Mi"

--- a/lagom-client-restaurant/menu-item-impl/src/main/resources/application.conf
+++ b/lagom-client-restaurant/menu-item-impl/src/main/resources/application.conf
@@ -1,10 +1,5 @@
 play.application.loader = com.example.menuitem.impl.MenuItemLoader
 
-http {
-  address = ${?HTTP_BIND_ADDRESS}
-  port = 9100
-}
-
 menu-item.cassandra.keyspace = menu_item
 
 cassandra-journal.keyspace = ${menu-item.cassandra.keyspace}
@@ -19,12 +14,3 @@ lagom.persistence.read-side.cassandra.keyspace = ${menu-item.cassandra.keyspace}
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}

--- a/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
+++ b/lagom-client-restaurant/menu-item-impl/src/main/resources/application.prod.conf
@@ -2,62 +2,17 @@ include "application.conf"
 
 play.http.secret.key = "unused secret"
 
-http {
-  address = ${?HTTP_BIND_ADDRESS}
-  port = 9000
-}
-
-play.filters.hosts {
-  # Requests that are not from one of these hosts will be rejected.
-  allowed = [${?ALLOWED_HOST}]
-}
-akka.discovery.method = kubernetes-api
+# Workaround for https://github.com/lagom/lagom/issues/2239
+akka.discovery.method = akka-dns
 
 akka.management.cluster.bootstrap {
   contact-point-discovery {
     discovery-method = kubernetes-api
     service-name = "menu-item"
-    port-name = "akka-mgmt-http"
     #Wait until there are 3 contact points present before attempting initial cluster formation
     required-contact-point-nr = 3
   }
 }
-
-cassandra.default {
-  ## list the contact points  here
-  contact-points = [${?CASSANDRA_CONTACT_POINT}]
-  ## override Lagom’s ServiceLocator-based ConfigSessionProvider
-  session-provider = akka.persistence.cassandra.ConfigSessionProvider
-}
-
-cassandra-journal {
-  contact-points = ${cassandra.default.contact-points}
-  session-provider = ${cassandra.default.session-provider}
-}
-
-cassandra-snapshot-store {
-  contact-points = ${cassandra.default.contact-points}
-  session-provider = ${cassandra.default.session-provider}
-}
-
-lagom.persistence.read-side.cassandra {
-  contact-points = ${cassandra.default.contact-points}
-  session-provider = ${cassandra.default.session-provider}
-}
-
-lagom.broker.kafka {
-  # If this is an empty string, then the Lagom service locator lookup will not be done,
-  # and the brokers configuration will be used instead.
-  service-name = ""
-
-  # The URLs of the Kafka brokers. Separate each URL with a comma.
-  # This will be ignored if the service-name configuration is non empty.
-  brokers = ${?KAFKA_BROKERS_SERVICE_URL}
-
-}
-
-#Shutdown if we have not joined a cluster after one minute.
-akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 300s
 
 # Telemetry
 # Lagom Cinnamon circuit breaker metrics - https://developer.lightbend.com/docs/telemetry/current/instrumentations/lagom/lagom-configuration.html#circuit-breaker-configuration


### PR DESCRIPTION
- Remove serialization bindings that Lagom 1.5.3 defines by default.
- Remove unnecessary shutdown-after-unsuccessful-join-seed-nodes
  override.
- Set default akka.discovery.method to akka-dns and link to GitHub issue
  for fixing the default setting.
- Remove HTTP address and port binding overrides.
- Remove explicit cluster bootstrap port name and rely on inferred port.
- Use service discovery for Cassandra and Kafka.
- Remove unused environment variables and port names.